### PR TITLE
Add Node.js as supported runtime

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -30,9 +30,19 @@ jobs:
       run: |
         pip install -r dev-requirements.txt
         python3 -m mypy *.py
-    - name: Build example layer
+    - name: Build example Python layer
       run: |
         cd tests/numpy/
         ../../layer-tool.py --list
         ../../layer-tool.py --build awesome-numpy
         du -h awesome-numpy.zip
+    - name: Set up Node v10
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: Build example Node.js layer
+      run: |
+        cd tests/aws-sdk/
+        ../../layer-tool.py --list
+        ../../layer-tool.py --build awesome-aws-sdk
+        du -h awesome-aws-sdk.zip

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Instead of manually copy & pasting build instructions for a Lambda Layer into yo
 Given a simple YAML file, it will:
 * create a new, clean directory for the lambda layer,
 * run specified pre-installation commands,
-* install python requirements with Pip in a virtual environment,
+* *Python*: install requirements with Pip in a virtual environment,
+* *Node.js*: install dependencies with NPM,
 * strip any binaries and libraries in the lambda directory,
 * apply global and layer-specific exclusion patterns,
 * bundle the remainder up into a ZIP archive.
@@ -66,6 +67,8 @@ $ ./layer-tool.py --publish awesome-numpy
 
 To learn how to use this tool to reduce the size of your layers, read the [post about creating a minimal boto3 layer](https://blog.cubieserver.de/2020/building-a-minimal-boto3-lambda-layer/).
 
+The [`tests` directory](./tests/) also serve as examples how to build layers for different runtimes (Python, Node.js).
+
 ## Lambda Environment
 
 To match the environment of AWS Lambda functions as closely as possible (especially when you use this tool on non-Linux systems), the tool should be run inside a Docker container.
@@ -92,8 +95,8 @@ In addition to the Python dependencies (`requirements.txt`), this tool currently
 
 ## Limitations
 
-Currently, this tool only supports building Python layers with Pip.
-However, it should be fairly straightforward to extend the functionality to other runtimes, e.g. JavaScript.
+Currently, this tool only supports building Python layers with Pip and Node.js layer with NPM.
+However, it should be fairly straightforward to extend the functionality to other runtimes and package managers.
 
 ## License
 

--- a/tests/aws-sdk/layers.yaml
+++ b/tests/aws-sdk/layers.yaml
@@ -1,0 +1,19 @@
+---
+version: '0.3'
+default_excludes:
+  - 'LICENSE'
+  - 'CHANGELOG'
+  - 'README.md'
+  - '.npmignore'
+
+layers:
+  awesome-aws-sdk:
+    description: 'AWS SDK JS 2.668'
+    runtimes: 'node10.x'
+    pre_installs:
+      - 'echo "Hello, World!" > node_modules/hello-world.txt'
+    requirements:
+      - 'aws-sdk@2.668.0'
+    excludes:
+      - '*/aws-sdk/*.d.ts'
+      - '*/aws-sdk/*.txt'


### PR DESCRIPTION
With this patch, lambda-layer-tool also supports building Lambda layer
for Node.js runtimes. It uses NPM to install the specified packages.